### PR TITLE
sc 90207/Test 1.25.16 K8sVersions

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -18,7 +18,7 @@ on:
       k8s-versions:
         description: 'The kubernetes versions to validate against'
         type: string
-        default: ''
+        default: '1.25.16'
     secrets:
       AWS_ACCESS_KEY:
         required: true


### PR DESCRIPTION
- feat(k8s-1.25-validation): allow K8s versions to provided at runtime
- feat(eks-upgrade): testing against Kubernetes 1.25.16
