### PR TITLE
fix: bump actions to remove deprecation warnings

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -34,20 +34,20 @@ jobs:
     name: "Validate Kubernetes Manifests"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.PAT_ATTEST_ADMIN_CI }}
           submodules: true
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY }}
           aws-region: eu-west-1
       - name: Login to ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-      # Pull separately to keep ouput on validation step clean
+        uses: aws-actions/amazon-ecr-login@v2
+      # Pull separately to keep output on validation step clean
       - name: Pull image from ECR
         run: |
           docker pull ${{ secrets.VALIDATION_IMAGE }}


### PR DESCRIPTION
Updating shared actions to remove warnings and prevent future breakage when github decide to finally act on these warnings.
See this [ticket](https://app.shortcut.com/attest/story/104607/update-github-actions-to-remove-deprecation-warnings) for more info.
Have pointed a build of the `bids-svc` at this branch:
* Warnings [before](https://github.com/Attest/bids-svc/actions/runs/8525650125)
* No warnings [afterwards](https://github.com/Attest/bids-svc/actions/runs/8601151079)