### PR TITLE
fix: set k8s-versions to default to empty

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -18,7 +18,7 @@ on:
       k8s-versions:
         description: 'The kubernetes versions to validate against'
         type: string
-        default: '1.25.16'
+        default: ''
     secrets:
       AWS_ACCESS_KEY:
         required: true


### PR DESCRIPTION
this has meant that workflows have been validating against 1.25 despite running 1.26 for over a month now

[no-sc]